### PR TITLE
Update yaml_groups.py

### DIFF
--- a/inventory_plugins/yaml_groups.py
+++ b/inventory_plugins/yaml_groups.py
@@ -73,7 +73,7 @@ hosts:
 '''
 
 import os
-from collections import MutableMapping, Sequence
+from collections.abc import MutableMapping, Sequence
 
 from ansible import constants as C
 from ansible.errors import AnsibleParserError


### PR DESCRIPTION
The change fixes the problem with Python v3.10:

ERROR! Unexpected Exception, this is probably a bug: cannot import name 'MutableMapping' from 'collections' (/usr/lib/python3.10/collections/__init__.py)